### PR TITLE
pass data-nete-rules to checkbox, checkboxList and radios

### DIFF
--- a/src/Inputs/CheckboxInput.php
+++ b/src/Inputs/CheckboxInput.php
@@ -11,6 +11,7 @@ namespace Czubehead\BootstrapForms\Inputs;
 
 
 use Czubehead\BootstrapForms\Traits\StandardValidationTrait;
+use Nette;
 use Nette\Forms\Controls\Checkbox;
 use Nette\Utils\Html;
 
@@ -32,10 +33,8 @@ class CheckboxInput extends Checkbox implements IValidationInput
 	 */
 	public function getControl()
 	{
-		parent::getControl();
-
 		return self::makeCheckbox($this->getHtmlName(), $this->getHtmlId(), $this->translate($this->caption), $this->value, FALSE, $this->required,
-			$this->disabled);
+			$this->disabled, $this->getRules());
 	}
 
 	/**
@@ -51,7 +50,7 @@ class CheckboxInput extends Checkbox implements IValidationInput
 	 */
 	public static function makeCheckbox(
 		$name, $htmlId, $caption = NULL, $checked = FALSE, $value = FALSE, $required = FALSE,
-		$disabled = FALSE)
+		$disabled = FALSE, $rules = NULL)
 	{
 		$label = Html::el('label', ['class' => ['custom-control', 'custom-checkbox']]);
 		$input = Html::el('input', [
@@ -62,6 +61,7 @@ class CheckboxInput extends Checkbox implements IValidationInput
 			'required' => $required,
 			'checked'  => $checked,
 			'id'       => $htmlId,
+			'data-nette-rules' => $rules ? Nette\Forms\Helpers::exportRules($rules) : null,
 		]);
 		if ($value !== FALSE) {
 			$input->attrs += [

--- a/src/Inputs/CheckboxListInput.php
+++ b/src/Inputs/CheckboxListInput.php
@@ -42,7 +42,7 @@ class CheckboxListInput extends CheckboxList implements IValidationInput
 		$c = 0;
 		foreach ($this->items as $value => $caption) {
 			$line = CheckboxInput::makeCheckbox($this->getHtmlName(), $baseId . $c, $caption, $this->isValueSelected($value),
-				$value, FALSE, $this->isValueDisabled($value));
+				$value, FALSE, $this->isValueDisabled($value), $this->getRules());
 
 			$fieldset->addHtml($line);
 			$c++;

--- a/src/Inputs/RadioInput.php
+++ b/src/Inputs/RadioInput.php
@@ -13,6 +13,7 @@ namespace Czubehead\BootstrapForms\Inputs;
 use Czubehead\BootstrapForms\Enums\RendererOptions;
 use Czubehead\BootstrapForms\Traits\ChoiceInputTrait;
 use Czubehead\BootstrapForms\Traits\StandardValidationTrait;
+use Nette;
 use Nette\Forms\Controls\ChoiceControl;
 use Nette\Utils\Html;
 
@@ -88,6 +89,12 @@ class RadioInput extends ChoiceControl implements IValidationInput
 
 			$container->addHtml($wrapper);
 			$c++;
+		}
+		if ($this->getRules()) {
+
+			$container->getChildren()[0] 	// wrapper
+				->getChildren()[0]			// input
+				->setAttribute('data-nette-rules', Nette\Forms\Helpers::exportRules($this->getRules()));
 		}
 
 		return $container;


### PR DESCRIPTION
Pass `data-nette-rules` for checkboxes and radios to be able to use interactively with netteForms.js